### PR TITLE
bug fix in transformation of 2D laser scans

### DIFF
--- a/libpointmatcher_ros/src/point_cloud.cpp
+++ b/libpointmatcher_ros/src/point_cloud.cpp
@@ -261,8 +261,8 @@ namespace PointMatcher_ros
         {
       
           listener->transformPoint(
-            fixedFrame,
-            curTime,
+            rosMsg.header.frame_id,
+            rosMsg.header.stamp,
             pin,
             fixedFrame,
             pout


### PR DESCRIPTION
I'm not 100% sure if this is correct, but I've tested it on a robot equipped with a 2D laser scanner, and it works (which was not the case with the previous version, since the ICP mapper expects the incoming point clouds to be represented in the scanner frame, and not in the odometry or whatever else frame).

If I understand it correctly, the whole point of this transformation at the beginning (when a new scan arrives) is to create a consistent point cloud, accounting for the motion during the acquisition, e.g., using the fixedFrame=odometry or another more-or-less-fixed frame.