### PR TITLE
Improved mapper node to perform localization with a given map and a specified initial pose.

### DIFF
--- a/libpointmatcher_ros/CMakeLists.txt
+++ b/libpointmatcher_ros/CMakeLists.txt
@@ -5,6 +5,7 @@ project(libpointmatcher_ros)
 find_package(catkin REQUIRED COMPONENTS
 roscpp
 sensor_msgs
+geometry_msgs
 nav_msgs
 tf
 tf_conversions
@@ -18,6 +19,7 @@ LIBRARIES pointmatcher_ros
 CATKIN_DEPENDS
 roscpp
 sensor_msgs
+geometry_msgs
 nav_msgs
 tf
 tf_conversions

--- a/libpointmatcher_ros/include/pointmatcher_ros/transform.h
+++ b/libpointmatcher_ros/include/pointmatcher_ros/transform.h
@@ -3,6 +3,7 @@
 
 #include "pointmatcher/PointMatcher.h"
 #include "nav_msgs/Odometry.h"
+#include "geometry_msgs/PoseStamped.h"
 #include "Eigen/Eigen"
 
 namespace ros
@@ -21,16 +22,22 @@ namespace PointMatcher_ros
 	// from tf/ROS
 	
 	template<typename T>
-	typename PointMatcher<T>::TransformationParameters transformListenerToEigenMatrix(const tf::TransformListener &listener, const std::string& target, const std::string& source, const ros::Time& stamp);
+	typename PointMatcher<T>::TransformationParameters transformListenerToEigenMatrix(const tf::TransformListener &listener, const std::string& target, const std::string& source, const ros::Time& stamp, const ros::Duration& timeout = ros::Duration(0.25));
 	
 	template<typename T>
 	typename PointMatcher<T>::TransformationParameters odomMsgToEigenMatrix(const nav_msgs::Odometry& odom);
 	
+	template<typename T>
+	typename PointMatcher<T>::TransformationParameters poseMsgToEigenMatrix(const geometry_msgs::Pose& pose);
+
 	// to tf/ROS
 	
 	template<typename T>
 	nav_msgs::Odometry eigenMatrixToOdomMsg(const typename PointMatcher<T>::TransformationParameters& inTr, const std::string& frame_id, const ros::Time& stamp);
 	
+	template<typename T>
+	geometry_msgs::PoseStamped eigenMatrixToPoseStampedMsg(const typename PointMatcher<T>::TransformationParameters& inTr, const std::string& frame_id, const ros::Time& stamp);
+
 	template<typename T>
 	tf::Transform eigenMatrixToTransform(const typename PointMatcher<T>::TransformationParameters& inTr);
 	

--- a/libpointmatcher_ros/package.xml
+++ b/libpointmatcher_ros/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
@@ -21,6 +22,7 @@
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf_conversions</run_depend>

--- a/libpointmatcher_ros/src/point_cloud.cpp
+++ b/libpointmatcher_ros/src/point_cloud.cpp
@@ -465,8 +465,10 @@ namespace PointMatcher_ros
 				if (hasColor)
 				{
 					// before color
-					memcpy(fPtr, reinterpret_cast<const uint8_t*>(&pmCloud.descriptors(0, pt)), scalarSize * colorPos);
-					fPtr += scalarSize * colorPos;
+					if (colorPos > 0) {
+						memcpy(fPtr, reinterpret_cast<const uint8_t*>(&pmCloud.descriptors(0, pt)), scalarSize * colorPos);
+						fPtr += scalarSize * colorPos;
+					}
 					// compact color
 					uint32_t rgba;
 					unsigned colorR(unsigned(pmCloud.descriptors(colorPos+0, pt) * 255.) & 0xFF);
@@ -475,11 +477,13 @@ namespace PointMatcher_ros
 					unsigned colorA(0);
 					if (colorCount == 4)
 						colorA = unsigned(pmCloud.descriptors(colorPos+3, pt) * 255.) & 0xFF;
-					rgba = colorA << 24 | colorR << 16 | colorG << 8 | colorB;
+					rgba = (uint32_t)colorA << 24 | (uint32_t)colorR << 16 | (uint32_t)colorG << 8 | (uint32_t)colorB;
 					memcpy(fPtr, reinterpret_cast<const uint8_t*>(&rgba), 4);
 					fPtr += 4;
 					// after color
-					memcpy(fPtr, reinterpret_cast<const uint8_t*>(&pmCloud.descriptors(postColorPos, pt)), scalarSize * postColorCount);
+					if (postColorCount > 0) {
+						memcpy(fPtr, reinterpret_cast<const uint8_t*>(&pmCloud.descriptors(postColorPos, pt)), scalarSize * postColorCount);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
- Fixed loading of point clouds with colors and normals.
- Added publishing of filtered and full sensor registered
sensor_msgs::PointCloud2 msgs
- Added publishing of geometry_msgs::PoseStamped in a new configurable
frame_id (baseFrame)
- Added option to invert tf (useful to bypass limitation of tf being a
tree)
- Added setup of initial pose from parameter server at startup
- Added setup of map using path from parameter server at startup
- Changed most ROS_INFO to ROS_DEBUG to not cause unnecessary console
information overload
- Added conversion between geometry_msgs::Pose and Eigen matrix
- Added timeout parameter to
PointMatcher_ros::transformListenerToEigenMatrix


Tested in Ubuntu 14.04 with ROS Indigo for comparison with DRL system:
https://github.com/carlosmccosta/dynamic_robot_localization_tests/blob/hydro-devel/launch/environments/asl/bags/ethzasl_kinect_dataset_high_complexity_slow_fly_movement.launch

roslaunch dynamic_robot_localization_tests ethzasl_kinect_dataset_high_complexity_slow_fly_movement.launch use_dynamic_robot_localization:=0 use_ethzasl_icp_mapper:=1

Note:
Requires pull request
https://github.com/ethz-asl/libpointmatcher/pull/103