### PR TITLE
Fix fieldTypes dim when converting to PMCloud

### DIFF
--- a/libpointmatcher_ros/src/point_cloud.cpp
+++ b/libpointmatcher_ros/src/point_cloud.cpp
@@ -52,6 +52,7 @@ namespace PointMatcher_ros
 			else if (name == "rgb" || name == "rgba")
 			{
 				descLabels.push_back(Label("color", (name == "rgba") ? 4 : 3));
+				fieldTypes.push_back(PM_types::DESCRIPTOR);
 				isFeature.push_back(false);
 			}
 			else if ((it+1) != rosMsg.fields.end() && it->name == "normal_x" && (it+1)->name == "normal_y")

--- a/libpointmatcher_ros/src/point_cloud.cpp
+++ b/libpointmatcher_ros/src/point_cloud.cpp
@@ -52,8 +52,8 @@ namespace PointMatcher_ros
 			else if (name == "rgb" || name == "rgba")
 			{
 				descLabels.push_back(Label("color", (name == "rgba") ? 4 : 3));
-				fieldTypes.push_back(PM_types::DESCRIPTOR);
 				isFeature.push_back(false);
+				fieldTypes.push_back(PM_types::DESCRIPTOR);
 			}
 			else if ((it+1) != rosMsg.fields.end() && it->name == "normal_x" && (it+1)->name == "normal_y")
 			{


### PR DESCRIPTION
In **rosMsgToPointMatcherCloud** there is a missing push_back on fieldTypes vector when rosMsg.fields.name is equal to "rgb" or "rgba".

The assertion on size equality fails as follow:

`/home/andrea/catkin_ws/src/ethzasl_icp_mapping/libpointmatcher_ros/src/point_cloud.cpp:108: typename PointMatcher<T>::DataPoints PointMatcher_ros::rosMsgToPointMatcherCloud(const PointCloud2&, bool) [with T = float; typename PointMatcher<T>::DataPoints = PointMatcher<float>::DataPoints; sensor_msgs::PointCloud2 = sensor_msgs::PointCloud2_<std::allocator<void> >]: Assertion 'fieldTypes.size() == rosMsg.fields.size()' failed.`