### PR TITLE
Inverted dynamic weight for angular distance between points.

### DIFF
--- a/ethzasl_icp_mapper/src/dynamic_mapper.cpp
+++ b/ethzasl_icp_mapper/src/dynamic_mapper.cpp
@@ -874,8 +874,8 @@ Mapper::DP* Mapper::updateMap(DP* newPointCloud, const PM::TransformationParamet
 					const float lastDyn = viewOnProbabilityDynamic(0,mapId);
 					const float lastStatic = viewOnProbabilityStatic(0, mapId);
 
-					const float c1 = (1 - (w_v*(1 - w_d1)));
-					const float c2 = w_v*(1 - w_d1);
+					const float c1 = (1 - (w_v*w_d1));
+					const float c2 = w_v*w_d1;
 					
 
 					//Lock dynamic point to stay dynamic under a threshold


### PR DESCRIPTION
I was comparing the code of the dynamic mapper with the paper "Long-term 3D map maintenance in dynamic environments". The paper states in chapter 3:

> 1) the greater the angle between the beam producing p
> and q, the less we change the knowledge on q,

If I translate this correctly to the code,

1. `w_d1` maps ["big angle", "small angle"] into [eps, 1.0]
2. `c2` represents the change of knowledge on q

Therefore it would be intuitive for me if `c2` was proportional to `w_d1` and not its inversion `1.0 - w_d1`.